### PR TITLE
Parent Modifier StepIndicatorAlignment (TOP /  CENTER / BOTTOM )

### DIFF
--- a/app/src/main/java/com/ss/stepperview/sample/MainActivity.kt
+++ b/app/src/main/java/com/ss/stepperview/sample/MainActivity.kt
@@ -3,20 +3,13 @@ package com.ss.stepperview.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.ss.stepperview.*
 import com.ss.stepperview.sample.data.StudyTaskStepperView
-import com.ss.stepperview.sample.data.steps
 import com.ss.stepperview.sample.data.studyTaskList
 import com.ss.stepperview.sample.ui.theme.StepperViewTheme
 

--- a/app/src/main/java/com/ss/stepperview/sample/data/StudyTaskExample.kt
+++ b/app/src/main/java/com/ss/stepperview/sample/data/StudyTaskExample.kt
@@ -28,7 +28,7 @@ fun StudyTaskUI(selected: Boolean, studyTask: StudyTask, modifier : Modifier = M
     val backgroundColor = if(selected) purple01 else green01
     val textColor = if(backgroundColor == purple01) Color.White else Color.Black
     Column(modifier = modifier
-        .padding(all = 8.dp)
+        .padding(start = 8.dp)
         .width(140.dp)
         .background(color = backgroundColor, shape = RoundedCornerShape(10.dp))
         .padding(all = 8.dp)){

--- a/app/src/main/java/com/ss/stepperview/sample/data/StudyTaskExample.kt
+++ b/app/src/main/java/com/ss/stepperview/sample/data/StudyTaskExample.kt
@@ -17,10 +17,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberImagePainter
 import com.ss.stepperview.layoutmodifier.StepAlignment
+import com.ss.stepperview.layoutmodifier.StepIndicatorAlignment
 import com.ss.stepperview.sample.R
 import com.ss.stepperview.sample.ui.theme.green01
 import com.ss.stepperview.sample.ui.theme.purple01
 import com.ss.stepperview.view.StepperView
+import com.ss.stepperview.view.StepperViewIndicator
 import com.ss.stepperview.view.StepsPerRow
 
 @Composable
@@ -93,7 +95,11 @@ fun DefaultPreview() {
 @Composable
 fun StudyTaskStepperView(studyTaskList: ArrayList<StudyTask>){
     StepperView(items = studyTaskList,
-    stepsPerRow = StepsPerRow.ONE) {
+    stepsPerRow = StepsPerRow.ONE,
+    indicator = {
+        StepperViewIndicator(modifier = Modifier
+            .align(StepIndicatorAlignment.CENTER)) }
+    ) {
         studyTaskList.forEachIndexed{ index, it ->
             var alignment = StepAlignment.LEFT
             if( index % 2 == 0 || index % 5 == 0 ){

--- a/stepperview/src/main/java/com/ss/stepperview/layout/StepLineLayoutList.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/layout/StepLineLayoutList.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.unit.Constraints
 import com.ss.stepperview.layout.base.BaseComponentList
 import com.ss.stepperview.layout.base.StepLineLayout
-import com.ss.stepperview.layout.helpers.IndicatorMeasureAndPlaceHelpers
 import com.ss.stepperview.layout.helpers.LineMeasureAndPlaceHelpers
 
 class StepLineLayoutList(

--- a/stepperview/src/main/java/com/ss/stepperview/layout/helpers/IndicatorMeasureAndPlaceHelpers.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/layout/helpers/IndicatorMeasureAndPlaceHelpers.kt
@@ -22,7 +22,7 @@ class IndicatorMeasureAndPlaceHelpersImpl(private val stepRows: StepRowLayoutLis
         val yPosition = when (alignment) {
             StepIndicatorAlignment.CENTER -> stepRows.rows[0].height / 2 - firstIndicatorHeight / 2
             StepIndicatorAlignment.TOP -> 0
-            StepIndicatorAlignment.BOTTOM -> stepRows.rows[0].height / 2 + firstIndicatorHeight
+            StepIndicatorAlignment.BOTTOM -> stepRows.rows[0].height - firstIndicatorHeight
         }
         val xPosition = stepRows.maxLeftIntrinsicWidth
         return Point(xPosition, yPosition)

--- a/stepperview/src/main/java/com/ss/stepperview/layoutmodifier/StepIndicatorAlignment.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/layoutmodifier/StepIndicatorAlignment.kt
@@ -18,7 +18,7 @@ internal class StepIndicatorAlignmentData(val stepIndicatorAlignment: StepIndica
     }
 }
 
-internal interface StepIndicatorScope {
+interface StepIndicatorScope {
     fun Modifier.align(stepIndicatorAlignment: StepIndicatorAlignment): Modifier
 }
 
@@ -29,6 +29,6 @@ internal object StepIndicatorScopeInstance : StepIndicatorScope {
         )
 }
 
-val Measurable.stepIndicatorAlignment
+internal val Measurable.stepIndicatorAlignment
     get() = (parentData as? StepIndicatorAlignmentData)?.stepIndicatorAlignment
         ?: StepIndicatorAlignment.CENTER

--- a/stepperview/src/main/java/com/ss/stepperview/view/StepperView.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/view/StepperView.kt
@@ -11,13 +11,16 @@ import com.ss.stepperview.layout.helpers.IndicatorMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layout.helpers.LineMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layout.helpers.StepRowMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layoutmodifier.StepIndicatorAlignment
-import com.ss.stepperview.layoutmodifier.StepIndicatorScopeInstance.align
+import com.ss.stepperview.layoutmodifier.StepIndicatorScopeInstance
 import com.ss.stepperview.layoutmodifier.StepScope
 import com.ss.stepperview.layoutmodifier.StepScopeInstance
+import com.ss.stepperview.layoutmodifier.StepIndicatorScope
+import com.ss.stepperview.layoutmodifier.StepIndicatorAlignmentData
+
 import kotlin.math.max
 
-private const val LAYOUTID_STEPPERVIEW_INDICATOR = "LAYOUTID_STEPPERVIEW_INDICATOR"
-private const val LAYOUTID_STEPPERVIEW_LINE = "LAYOUTID_STEPPERVIEW_LINE"
+const val LAYOUTID_STEPPERVIEW_INDICATOR = "LAYOUTID_STEPPERVIEW_INDICATOR"
+const val LAYOUTID_STEPPERVIEW_LINE = "LAYOUTID_STEPPERVIEW_LINE"
 
 enum class StepsPerRow(val noOfSteps: Int) {
     ONE(1), TWO(2)
@@ -27,6 +30,10 @@ enum class StepsPerRow(val noOfSteps: Int) {
 fun StepperView(
     items: List<Any>,
     stepsPerRow: StepsPerRow = StepsPerRow.ONE,
+    indicator: @Composable StepIndicatorScope.() -> Unit = {
+        StepperViewIndicator(modifier = Modifier
+        .align(StepIndicatorAlignment.BOTTOM)) },
+
     content: @Composable StepScope.() -> Unit
 ) {
     StepperViewLayout(
@@ -34,13 +41,7 @@ fun StepperView(
         stepsPerRow = stepsPerRow,
         indicatorContent = {
             repeat(items.size) {
-                StepperViewIndicator(
-                    modifier = Modifier
-                        .layoutId(
-                            LAYOUTID_STEPPERVIEW_INDICATOR.plus(it)
-                        )
-                        .align(StepIndicatorAlignment.TOP)
-                )
+                    StepIndicatorScopeInstance.indicator()
             }
         },
         lineContent = {
@@ -60,13 +61,13 @@ fun StepperView(
 fun StepperViewLayout(
     modifier: Modifier = Modifier,
     stepsPerRow: StepsPerRow,
-    indicatorContent: @Composable () -> Unit,
+    indicatorContent: @Composable StepIndicatorScope.() -> Unit,
     lineContent: @Composable () -> Unit,
     stepContent: @Composable StepScope.() -> Unit
 ) {
     Layout(
         content = {
-            indicatorContent()
+            StepIndicatorScopeInstance.indicatorContent()
             lineContent()
             StepScopeInstance.stepContent()
         },
@@ -76,11 +77,10 @@ fun StepperViewLayout(
         val stepsMeasurables = measurables
             .filter {
                 it.layoutId.toString().contains(LAYOUTID_STEPPERVIEW_LINE)
-                    .not() && it.layoutId.toString().contains(LAYOUTID_STEPPERVIEW_INDICATOR)
-                    .not()
+                    .not() && it.parentData !is StepIndicatorAlignmentData
             }
         val indicatorMeasurables = measurables
-            .filter { it.layoutId.toString().contains(LAYOUTID_STEPPERVIEW_INDICATOR) }
+            .filter { it.parentData is StepIndicatorAlignmentData }
         val lineMeasurables = measurables
             .filter { it.layoutId.toString().contains(LAYOUTID_STEPPERVIEW_LINE) }
 

--- a/stepperview/src/main/java/com/ss/stepperview/view/StepperViewIndicator.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/view/StepperViewIndicator.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun StepperViewIndicator(modifier: Modifier) {
+fun StepperViewIndicator(modifier: Modifier = Modifier) {
     OutlinedButton(
         onClick = { /*TODO*/ },
         modifier = modifier.size(10.dp),

--- a/stepperview/src/test/java/com/ss/stepperview/IndicatorMeasureAndPlaceHelperTest.kt
+++ b/stepperview/src/test/java/com/ss/stepperview/IndicatorMeasureAndPlaceHelperTest.kt
@@ -7,6 +7,7 @@ import com.ss.stepperview.layoutmodifier.StepIndicatorAlignment
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -21,6 +22,7 @@ class IndicatorMeasureAndPlaceHelperTest {
         val rows : ArrayList<StepRowLayout> = mock()
         whenever(stepRows.rows).thenReturn(rows)
         whenever(stepRows.maxLeftIntrinsicWidth).thenReturn(300)
+        whenever(stepRows.verticalSpacing(Mockito.anyInt())).thenReturn(20)
         (0..4).forEach {
             val stepRowLayout = mock<StepRowLayout>()
             whenever(stepRowLayout.height).thenReturn(150 * (it+1) )
@@ -38,7 +40,10 @@ class IndicatorMeasureAndPlaceHelperTest {
 
     @Test
     fun `when indicator alignment is top, first indicator should be aligned to top of steps of that row`(){
-
+        val indicatorHeight = 30
+        val indicators = IndicatorMeasureAndPlaceHelpersImpl(stepRows)
+        val resultYPosition = indicators.firstIndicatorPosition(indicatorHeight, StepIndicatorAlignment.TOP).y
+        assertThat(resultYPosition).isEqualTo(0)
     }
 
     @Test
@@ -51,7 +56,47 @@ class IndicatorMeasureAndPlaceHelperTest {
 
     @Test
     fun `when indicator alignment is bottom, indicator should be aligned to bottom of steps of that row`(){
-
+        val indicatorHeight = 30
+        val indicators = IndicatorMeasureAndPlaceHelpersImpl(stepRows)
+        val resultYPosition = indicators.firstIndicatorPosition(indicatorHeight, StepIndicatorAlignment.BOTTOM).y
+        assertThat(resultYPosition).isEqualTo(120)
     }
+
+    // As first Indicator position is used for first position.
+    @Test
+    fun `when indicator alignment is Top or Center or Bottom, vertical spacing of the indicator for index 0 should be always Zero`(){
+        val indicatorHeight = 30
+        val indicators = IndicatorMeasureAndPlaceHelpersImpl(stepRows)
+
+        assertThat(indicators.verticalSpacing(indicatorHeight, 0, StepIndicatorAlignment.TOP)).isEqualTo(0)
+        assertThat(indicators.verticalSpacing(indicatorHeight, 0, StepIndicatorAlignment.CENTER)).isEqualTo(0)
+        assertThat(indicators.verticalSpacing(indicatorHeight, 0, StepIndicatorAlignment.BOTTOM)).isEqualTo(0)
+    }
+
+    @Test
+    fun `when indicator alignment is top, vertical spacing above the indicator should be sum of steprow height and vertical spacing`(){
+        val indicatorHeight = 30
+        val indicators = IndicatorMeasureAndPlaceHelpersImpl(stepRows)
+        val verticalSpacing = indicators.verticalSpacing(indicatorHeight, 1, StepIndicatorAlignment.TOP)
+        assertThat(verticalSpacing).isEqualTo(170)
+    }
+
+    @Test
+    fun `when indicator alignment is center, vertical spacing above the indicator should be sum (half of current steprow height , half of previous steprow height , vertical spacing below previous stepRow`(){
+        val indicatorHeight = 30
+        val indicators = IndicatorMeasureAndPlaceHelpersImpl(stepRows)
+        val verticalSpacing = indicators.verticalSpacing(indicatorHeight, 1, StepIndicatorAlignment.CENTER)
+        assertThat(verticalSpacing).isEqualTo(245)
+    }
+
+    @Test
+    fun `when indicator alignment is bottom, vertical spacing above the indicator should be sum (current steprow height, vertical spacing below previous stepRow`(){
+        val indicatorHeight = 30
+        val indicators = IndicatorMeasureAndPlaceHelpersImpl(stepRows)
+        val verticalSpacing = indicators.verticalSpacing(indicatorHeight, 1, StepIndicatorAlignment.BOTTOM)
+        assertThat(verticalSpacing).isEqualTo(320)
+    }
+
+
 }
 


### PR DESCRIPTION
Fixes #9 

# Why is this important
This PR helps developers to customize the position of StepIndicatorView either to the Top / Center / Bottom of the steps.

# How to use
```kotlin
@Composable
fun sampleUI(studyTaskList: List<String>) {

    StepperView(items = studyTaskList,
        indicator = {
            StepperViewIndicator(
                modifier = Modifier.align(StepIndicatorAlignment.CENTER)
            )
        }
    ) {
        studyTaskList.forEachIndexed { index, it ->
            ("Step ${it}")
        }
    }
}
```
## StepIndicatorAlignment.BOTTOM
[<img src="https://user-images.githubusercontent.com/4975407/147836581-79123952-c90a-4ed0-8d55-5be04968936f.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147836581-79123952-c90a-4ed0-8d55-5be04968936f.png)
## StepIndicatorAlignment.CENTER
[<img src="https://user-images.githubusercontent.com/4975407/147836583-7d7f0c7b-5c72-41ec-bebd-32b4c712d1f6.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147836583-7d7f0c7b-5c72-41ec-bebd-32b4c712d1f6.png)
## StepIndicatorAlignment.TOP
[<img src="https://user-images.githubusercontent.com/4975407/147836584-bd583cc4-f7ae-47f3-bf81-39820467b4f9.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147836584-bd583cc4-f7ae-47f3-bf81-39820467b4f9.png)
