### PR TITLE
Configurable Vertical Spacing

### DIFF
--- a/app/src/main/java/com/ss/stepperview/sample/data/StudyTaskExample.kt
+++ b/app/src/main/java/com/ss/stepperview/sample/data/StudyTaskExample.kt
@@ -96,6 +96,7 @@ fun DefaultPreview() {
 fun StudyTaskStepperView(studyTaskList: ArrayList<StudyTask>){
     StepperView(items = studyTaskList,
     stepsPerRow = StepsPerRow.ONE,
+    verticalSpacing = 100,
     indicator = {
         StepperViewIndicator(modifier = Modifier
             .align(StepIndicatorAlignment.CENTER)) }

--- a/stepperview/src/main/java/com/ss/stepperview/layout/helpers/StepRowMeasureAndPlaceHelpers.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/layout/helpers/StepRowMeasureAndPlaceHelpers.kt
@@ -1,11 +1,11 @@
 package com.ss.stepperview.layout.helpers
 
-private const val VERTICAL_SPACING = 20
+internal const val DEFAULT_VERTICAL_SPACING = 20
 
 interface StepRowMeasureAndPlaceHelpers {
     fun verticalSpacing(belowStepRowWithIndex: Int): Int
 }
 
-class StepRowMeasureAndPlaceHelpersImpl : StepRowMeasureAndPlaceHelpers {
-    override fun verticalSpacing(belowStepRowWithIndex: Int): Int = VERTICAL_SPACING
+class StepRowMeasureAndPlaceHelpersImpl(val verticalSpacing: Int) : StepRowMeasureAndPlaceHelpers {
+    override fun verticalSpacing(belowStepRowWithIndex: Int): Int = verticalSpacing
 }

--- a/stepperview/src/main/java/com/ss/stepperview/view/StepperView.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/view/StepperView.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.layout.layoutId
 import com.ss.stepperview.layout.StepRowLayoutList
 import com.ss.stepperview.layout.StepIndicatorLayoutList
 import com.ss.stepperview.layout.StepLineLayoutList
+import com.ss.stepperview.layout.helpers.DEFAULT_VERTICAL_SPACING
 import com.ss.stepperview.layout.helpers.IndicatorMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layout.helpers.LineMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layout.helpers.StepRowMeasureAndPlaceHelpersImpl
@@ -30,14 +31,15 @@ enum class StepsPerRow(val noOfSteps: Int) {
 fun StepperView(
     items: List<Any>,
     stepsPerRow: StepsPerRow = StepsPerRow.ONE,
+    verticalSpacing : Int = DEFAULT_VERTICAL_SPACING,
     indicator: @Composable StepIndicatorScope.() -> Unit = {
         StepperViewIndicator(modifier = Modifier
         .align(StepIndicatorAlignment.BOTTOM)) },
-
     content: @Composable StepScope.() -> Unit
 ) {
     StepperViewLayout(
         Modifier,
+        verticalSpacing = verticalSpacing,
         stepsPerRow = stepsPerRow,
         indicatorContent = {
             repeat(items.size) {
@@ -61,6 +63,7 @@ fun StepperView(
 fun StepperViewLayout(
     modifier: Modifier = Modifier,
     stepsPerRow: StepsPerRow,
+    verticalSpacing:Int,
     indicatorContent: @Composable StepIndicatorScope.() -> Unit,
     lineContent: @Composable () -> Unit,
     stepContent: @Composable StepScope.() -> Unit
@@ -86,7 +89,7 @@ fun StepperViewLayout(
 
 
         layout(constraints.maxWidth, constraints.maxHeight) {
-            val stepRowsMeasureAndPlaceHelpersImpl = StepRowMeasureAndPlaceHelpersImpl()
+            val stepRowsMeasureAndPlaceHelpersImpl = StepRowMeasureAndPlaceHelpersImpl(verticalSpacing)
             val stepRowsLayout = StepRowLayoutList(stepsMeasurables, stepsPerRow, stepRowsMeasureAndPlaceHelpersImpl)
             val indicatorMeasureAndPlaceHelpersImpl = IndicatorMeasureAndPlaceHelpersImpl(stepRowsLayout)
             val indicatorsLayout =


### PR DESCRIPTION
Fixes #8 
This is a small PR that changes the defaulted vertical spacing to configurable vertical spacing.

## How to use
```kotlin
@Composable
fun StudyTaskStepperView(studyTaskList: ArrayList<StudyTask>){
    StepperView(items = studyTaskList,
    stepsPerRow = StepsPerRow.ONE,
    verticalSpacing = 100) {
        studyTaskList.forEach{ it ->
            StudyTaskUI(studyTask = it)
        }
    }
}
```

## Testing
Vertical spacing is made configurable and tested if it works fine with step Alignments TOP/CENTER/BOTTOM.

### Vertical spacing = 20 , StepIndicatorAlignment.TOP
[<img src="https://user-images.githubusercontent.com/4975407/147837592-ba31d9ab-1733-495c-b58b-3831a27f6300.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147837592-ba31d9ab-1733-495c-b58b-3831a27f6300.png)
### Vertical spacing = 100 , StepIndicatorAlignment.TOP
[<img src="https://user-images.githubusercontent.com/4975407/147837690-857aff9a-af38-4c1d-b1eb-9178557c0095.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147837690-857aff9a-af38-4c1d-b1eb-9178557c0095.png)
### Vertical spacing = 100 , StepIndicatorAlignment.BOTTOM
[<img src="https://user-images.githubusercontent.com/4975407/147837595-f1e55767-fa0d-44e0-9601-c92f0ae1755e.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147837595-f1e55767-fa0d-44e0-9601-c92f0ae1755e.png)
### Vertical spacing = 100 , StepIndicatorAlignment.CENTER
[<img src="https://user-images.githubusercontent.com/4975407/147837596-7cfe8a9e-84d4-4da9-ba68-ef8c9e365acb.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147837596-7cfe8a9e-84d4-4da9-ba68-ef8c9e365acb.png)

