### PR TITLE
StepsPerRow.TWO - Steps aligned with respect to indicator alignment

### DIFF
--- a/stepperview/src/main/java/com/ss/stepperview/layout/base/StepComponentLayout.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/layout/base/StepComponentLayout.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.unit.Constraints
 import com.ss.stepperview.layoutmodifier.StepIndicatorAlignment
+import com.ss.stepperview.layoutmodifier.StepVerticalAlignment
 import com.ss.stepperview.layoutmodifier.stepAlignment
 import com.ss.stepperview.layoutmodifier.stepIndicatorAlignment
 
@@ -14,6 +15,7 @@ interface StepComponentLayout {
     var yPosition: Int
     var width: Int
     var height:Int
+    var placeable: Placeable?
     fun measure(constraints: Constraints)
     val place: Placeable.PlacementScope.(x: Int, y: Int) -> Unit
 }
@@ -23,7 +25,7 @@ internal class BaseStepComponentLayout(val measurable: Measurable) : StepCompone
         get() = measurable.maxIntrinsicWidth(Int.MAX_VALUE)
     override val intrinsicHeight: Int
         get() = measurable.maxIntrinsicHeight(Int.MAX_VALUE)
-    private var placeable: Placeable? = null
+    override var placeable: Placeable? = null
     override var xPosition: Int = 0
     override var yPosition: Int = 0
     override var width: Int = 0
@@ -42,9 +44,9 @@ internal class BaseStepComponentLayout(val measurable: Measurable) : StepCompone
     }
 }
 
-class StepLayout(private val measurable: Measurable) :
+class StepLayout(private val measurable: Measurable,val stepVerticalAlignment: StepVerticalAlignment) :
     StepComponentLayout by BaseStepComponentLayout(measurable = measurable) {
-    val stepAlignment
+    val stepHorizontalAlignment
         get() = measurable.stepAlignment
 }
 

--- a/stepperview/src/main/java/com/ss/stepperview/layoutmodifier/StepAlignment.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/layoutmodifier/StepAlignment.kt
@@ -10,6 +10,12 @@ enum class StepAlignment {
     RIGHT
 }
 
+enum class StepVerticalAlignment{
+    TOP,
+    CENTER,
+    BOTTOM
+}
+
 internal class StepAlignmentData(val stepAlignment: StepAlignment) : ParentDataModifier {
     override fun Density.modifyParentData(parentData: Any?): Any {
         return this@StepAlignmentData

--- a/stepperview/src/main/java/com/ss/stepperview/view/StepperView.kt
+++ b/stepperview/src/main/java/com/ss/stepperview/view/StepperView.kt
@@ -1,5 +1,6 @@
 package com.ss.stepperview.view
 
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
@@ -11,12 +12,10 @@ import com.ss.stepperview.layout.helpers.DEFAULT_VERTICAL_SPACING
 import com.ss.stepperview.layout.helpers.IndicatorMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layout.helpers.LineMeasureAndPlaceHelpersImpl
 import com.ss.stepperview.layout.helpers.StepRowMeasureAndPlaceHelpersImpl
-import com.ss.stepperview.layoutmodifier.StepIndicatorAlignment
-import com.ss.stepperview.layoutmodifier.StepIndicatorScopeInstance
-import com.ss.stepperview.layoutmodifier.StepScope
-import com.ss.stepperview.layoutmodifier.StepScopeInstance
-import com.ss.stepperview.layoutmodifier.StepIndicatorScope
+import com.ss.stepperview.layoutmodifier.*
 import com.ss.stepperview.layoutmodifier.StepIndicatorAlignmentData
+import com.ss.stepperview.layoutmodifier.StepIndicatorScopeInstance
+import com.ss.stepperview.layoutmodifier.StepScopeInstance
 
 import kotlin.math.max
 
@@ -30,6 +29,7 @@ enum class StepsPerRow(val noOfSteps: Int) {
 @Composable
 fun StepperView(
     items: List<Any>,
+    modifier: Modifier = Modifier,
     stepsPerRow: StepsPerRow = StepsPerRow.ONE,
     verticalSpacing : Int = DEFAULT_VERTICAL_SPACING,
     indicator: @Composable StepIndicatorScope.() -> Unit = {
@@ -38,7 +38,7 @@ fun StepperView(
     content: @Composable StepScope.() -> Unit
 ) {
     StepperViewLayout(
-        Modifier,
+        modifier,
         verticalSpacing = verticalSpacing,
         stepsPerRow = stepsPerRow,
         indicatorContent = {
@@ -84,13 +84,22 @@ fun StepperViewLayout(
             }
         val indicatorMeasurables = measurables
             .filter { it.parentData is StepIndicatorAlignmentData }
+        val stepVerticalAlignmentList : List<StepVerticalAlignment> = indicatorMeasurables
+            .map { it.stepIndicatorAlignment }
+            .map {
+                when(it){
+                    StepIndicatorAlignment.TOP -> StepVerticalAlignment.TOP
+                    StepIndicatorAlignment.CENTER -> StepVerticalAlignment.CENTER
+                    StepIndicatorAlignment.BOTTOM -> StepVerticalAlignment.BOTTOM
+                }
+            }
         val lineMeasurables = measurables
             .filter { it.layoutId.toString().contains(LAYOUTID_STEPPERVIEW_LINE) }
 
 
         layout(constraints.maxWidth, constraints.maxHeight) {
             val stepRowsMeasureAndPlaceHelpersImpl = StepRowMeasureAndPlaceHelpersImpl(verticalSpacing)
-            val stepRowsLayout = StepRowLayoutList(stepsMeasurables, stepsPerRow, stepRowsMeasureAndPlaceHelpersImpl)
+            val stepRowsLayout = StepRowLayoutList(stepsMeasurables, stepsPerRow, stepRowsMeasureAndPlaceHelpersImpl, stepVerticalAlignmentList)
             val indicatorMeasureAndPlaceHelpersImpl = IndicatorMeasureAndPlaceHelpersImpl(stepRowsLayout)
             val indicatorsLayout =
                 StepIndicatorLayoutList(indicatorMeasurables, indicatorMeasureAndPlaceHelpersImpl)


### PR DESCRIPTION
Fixes #7 

This PR fixes the issues with the alignment of steps in a Row with respect to each other and steps indicator location.

## BEFORE
## StepsPerRow.TWO && StepAlignment.CENTER
[<img src="https://user-images.githubusercontent.com/4975407/147961525-bd14c097-d8e3-451c-acf8-6d0a465765f1.png" width="300"/>]

## StepsPerRow.TWO && StepAlignment.BOTTOM
[<img src="https://user-images.githubusercontent.com/4975407/147961543-3555f12c-72c5-4781-a3f0-9ef54a4dac85.png" width="300"/>]

## StepsPerRow.TWO && StepAlignment.TOP
[<img src="https://user-images.githubusercontent.com/4975407/147963492-74e19984-fd3e-4505-9d3e-acc146ac1817.png" width="300"/>]


Currently, the steps with StepIndicatorAlignment.TOP looks fine. But when the StepIndicatorAlignment is CENTER or BOTTOM, the step Alignments doesn't look good.

So, This PR fixes the alignment of steps based on the StepIndicatorAlignment.

## AFTER
[<img src="https://user-images.githubusercontent.com/4975407/147963743-31220b60-0a5d-44d5-89a0-9cbd7dbbdeb8.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147963743-31220b60-0a5d-44d5-89a0-9cbd7dbbdeb8.png)

[<img src="https://user-images.githubusercontent.com/4975407/147963757-8d6b6856-f82a-4557-b721-18f7a718bba6.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147963757-8d6b6856-f82a-4557-b721-18f7a718bba6.png)

[<img src="https://user-images.githubusercontent.com/4975407/147963761-1774d88a-3754-440c-8135-8d2d484273b2.png" width="300"/>](https://user-images.githubusercontent.com/4975407/147963761-1774d88a-3754-440c-8135-8d2d484273b2.png)
